### PR TITLE
Update ng-device-detector.js

### DIFF
--- a/ng-device-detector.js
+++ b/ng-device-detector.js
@@ -9,7 +9,7 @@ angular.module("ng.deviceDetector",[])
 		        userAgent: ua,
 				os:{
 						windows:/\bWindows\b/.test(ua),
-						mac:/\bMacOS\b/.test(ua),
+						mac:/\bMac OS\b/.test(ua),
 						linux:/\bLinux\b/.test(ua),
 						unix:/\bUNIX\b/.test(ua),
 						android:/\bAndroid\b/.test(ua),


### PR DESCRIPTION
Mac OS should have a space, otherwise it causes the class to be os-undefined
