### PR TITLE
iOS before Mac-os in class definition

### DIFF
--- a/ng-device-detector.js
+++ b/ng-device-detector.js
@@ -35,8 +35,8 @@ angular.module("ng.deviceDetector",[])
 		};
 
 	    deviceInfo.os = deviceInfo.raw.os.windows ? "windows" :
-	        (deviceInfo.raw.os.mac ? "mac" :
-        		(deviceInfo.raw.os.ios ? "ios" :
+        	(deviceInfo.raw.os.ios ? "ios" :
+	        	(deviceInfo.raw.os.mac ? "mac" :
 		            (deviceInfo.raw.os.android ? "android" :
 		                (deviceInfo.raw.os.unix ? "unix" :
 		                    (deviceInfo.raw.os.linux ? "linux" :


### PR DESCRIPTION
iPad etc also have mac in their UserAgent, putting iOS before mac in class-generation makes sure right os is selected.
