### PR TITLE
add re-tree module dependency in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,5 +22,8 @@
     "bower_components",
     "test",
     "tests"
-  ]
+  ],
+  "dependencies": {
+    "re-tree": ">=0.0.2"
+  },
 }

--- a/bower.json
+++ b/bower.json
@@ -25,5 +25,5 @@
   ],
   "dependencies": {
     "re-tree": ">=0.0.2"
-  },
+  }
 }


### PR DESCRIPTION
I think you should add re-tree dependency in bower.json file
otherwise I must install re-tree modules manually.

Thanks.