### PR TITLE
Switched Chromebooks from mobile to 'isDesktop'

### DIFF
--- a/ng-device-detector.js
+++ b/ng-device-detector.js
@@ -265,7 +265,6 @@
                         DEVICES.I_POD,
                         DEVICES.BLACKBERRY,
                         DEVICES.FIREFOX_OS,
-                        DEVICES.CHROME_BOOK,
                         DEVICES.WINDOWS_PHONE,
                         DEVICES.VITA
                     ].some(function (item) {
@@ -276,8 +275,7 @@
                 deviceInfo.isTablet = function () {
                     return [
                         DEVICES.I_PAD,
-                        DEVICES.FIREFOX_OS,
-                        DEVICES.CHROME_BOOK
+                        DEVICES.FIREFOX_OS
                     ].some(function (item) {
                             return deviceInfo.device == item;
                         });
@@ -286,6 +284,7 @@
                 deviceInfo.isDesktop = function () {
                     return [
                         DEVICES.PS4,
+                        DEVICES.CHROME_BOOK,
                         DEVICES.UNKNOWN
                     ].some(function (item) {
                             return deviceInfo.device == item;


### PR DESCRIPTION
Chromebooks were flagged as being mobile and tablet, probably a mistake because of the fact they returned the 'device' field at all. This fix labels them correctly as 'isDesktop'.

Chromebooks should be considered desktop rather than mobile or tablet because of the form factor, as well as them not obeying the typical mobile/tablet rules such as not auto-playing video.

(I didn't bump the version number up or anything else, just fixed the one file. Please handle the versioning as you please)