### PR TITLE
Import 'ua-device-detector' dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 require('re-tree');
+require('ua-device-detector');
 require('./ng-device-detector');
 module.exports = 'ng.deviceDetector';


### PR DESCRIPTION
`ua-device-detector` is listed as a dependency, but it's not actually required in the `index.js` and thus doesn't load when loaded via require or import.